### PR TITLE
Hacky fix

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,6 +1,6 @@
-@import 'formation/styles/extensions';
-@import 'formation/styles/config/foundation/colors/index-colors';
-@import 'formation/styles/config/foundation/breakpoints/variables-breakpoints';
-@import 'formation/styles/config/layout/index-layout';
+@import '@condenast/platform-styleguide/src/styles/extensions';
+@import '@condenast/platform-styleguide/src/styles/config/foundation/colors/index-colors';
+@import '@condenast/platform-styleguide/src/styles/config/foundation/breakpoints/variables-breakpoints';
+@import '@condenast/platform-styleguide/src/styles/config/layout/index-layout';
 
 @import 'pod-styles';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,8 +13,6 @@ module.exports = function(defaults) {
     }
   });
 
-  //app.import('node_modules/breakpoint-sass/stylesheets/_breakpoint.scss');
-
   // Use `app.import` to add additional libraries to the generated
   // output files.
   //

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,7 +6,14 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     // Add options here
+    sassOptions: {
+      includePaths: [
+        'node_modules'
+      ]
+    }
   });
+
+  //app.import('node_modules/breakpoint-sass/stylesheets/_breakpoint.scss');
 
   // Use `app.import` to add additional libraries to the generated
   // output files.

--- a/lib/copilot-components/addon/components/foo-bar/style.scss
+++ b/lib/copilot-components/addon/components/foo-bar/style.scss
@@ -1,4 +1,4 @@
 section {
   background-color: pink;
- // color: $button-text-dark;
+  color: $button-text-dark;
 }

--- a/lib/copilot-components/addon/styles/addon.scss
+++ b/lib/copilot-components/addon/styles/addon.scss
@@ -1,5 +1,6 @@
-@import 'pod-styles';
+@import '@condenast/platform-styleguide/src/styles/extensions';
+@import '@condenast/platform-styleguide/src/styles/config/foundation/colors/index-colors';
+@import '@condenast/platform-styleguide/src/styles/config/foundation/breakpoints/variables-breakpoints';
+@import '@condenast/platform-styleguide/src/styles/config/layout/index-layout';
 
-body {
-  @debug 'hello world';
-}
+@import 'pod-styles';


### PR DESCRIPTION
Here is a solution to get this build working:
1. Forgo trying to use the addon system to pull in styles. Meaning, revert the funnel hacks in [here](https://github.com/CondeNast-Copilot/platform-styleguide/commit/39bcf1c2954027d1854c0e4c15f599ce4490e51f)
2. Make `node_modules` part of sassOptions.includePaths like [here](https://github.com/CondeNast-Copilot/platform-styleguide/blob/master/webpack.config.dev.js#L64)
3. Pull in all the styles explicitly through their file paths (chop off `node_modules`)